### PR TITLE
v2.4.2: fix repo URLs in manifest/README, upgrade Actions off Node 20

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -11,7 +11,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Get version from manifest
         id: version

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,10 +14,10 @@ jobs:
         python-version: ["3.11", "3.12"]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -21,7 +21,7 @@ jobs:
     name: Hassfest Validation
     runs-on: ubuntu-latest
     steps:
-      - uses: "actions/checkout@v3"
+      - uses: "actions/checkout@v5"
       - uses: home-assistant/actions/hassfest@master
 
   lint:
@@ -29,10 +29,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ Two rules for contributors:
 
 ## [Unreleased]
 
+## [v2.4.2] - 2026-06-02
+
+### Fixed
+- `manifest.json` `documentation` and `issue_tracker` URLs (and the README
+  links) pointed at the non-existent `Tineco-HACS-Integration` repo; corrected
+  to `Tineco-Integration`. The HACS "Documentation" / "Issues" buttons now
+  resolve.
+
+### Changed
+- GitHub Actions upgraded off the deprecated Node 20 runtime:
+  `actions/checkout` v3/v4 → v5, `actions/setup-python` v5 → v6.
+
 ## [v2.4.1] - 2026-06-02
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Control your Tineco smart devices through Home Assistant using this custom integration.
 
-Current version: **2.4.1** — supports global (`IE`, `US`, etc.) and China (`CN`) regions. Developed against the S7 Flashdry; other models (incl. Floor One S5 / S5 Pro) work with community feedback.
+Current version: **2.4.2** — supports global (`IE`, `US`, etc.) and China (`CN`) regions. Developed against the S7 Flashdry; other models (incl. Floor One S5 / S5 Pro) work with community feedback.
 
 ### Community Lovelace Card
 
@@ -74,7 +74,7 @@ See [CHANGELOG.md](CHANGELOG.md) for the full history.
 
 1. Open **HACS** → **Integrations**
 2. Three-dots menu → **Custom repositories**
-3. Add `https://github.com/wheeller123/Tineco-HACS-Integration` with category **Integration**
+3. Add `https://github.com/wheeller123/Tineco-Integration` with category **Integration**
 4. Search for **Tineco** and install
 5. Restart Home Assistant
 6. **Settings** → **Devices & Services** → **Add Integration** → search for **Tineco**
@@ -259,7 +259,7 @@ If something isn't working, please open an issue with logs attached so the cause
 
 4. Back on the integration page, click **Disable debug logging**. Home Assistant will prompt you to save the log file — download it.
 
-**Open the issue here:** https://github.com/wheeller123/Tineco-HACS-Integration/issues — attach the log file and include the integration version, region (`IE` / `US` / `CN` / …), device model, and a short description of what you did. Scrub anything that looks like a token, account ID, or phone number before posting.
+**Open the issue here:** https://github.com/wheeller123/Tineco-Integration/issues — attach the log file and include the integration version, region (`IE` / `US` / `CN` / …), device model, and a short description of what you did. Scrub anything that looks like a token, account ID, or phone number before posting.
 
 
 ## Credits

--- a/custom_components/tineco/manifest.json
+++ b/custom_components/tineco/manifest.json
@@ -3,10 +3,10 @@
   "name": "tineco",
   "codeowners": ["@wheeller123"],
   "config_flow": true,
-  "documentation": "https://github.com/wheeller123/Tineco-HACS-Integration",
+  "documentation": "https://github.com/wheeller123/Tineco-Integration",
   "integration_type": "device",
   "iot_class": "cloud_polling",
-  "issue_tracker": "https://github.com/wheeller123/Tineco-HACS-Integration/issues",
+  "issue_tracker": "https://github.com/wheeller123/Tineco-Integration/issues",
   "requirements": ["requests>=2.28.0"],
-  "version": "2.4.1"
+  "version": "2.4.2"
 }


### PR DESCRIPTION
- manifest.json documentation/issue_tracker URLs (and README links) pointed at the non-existent Tineco-HACS-Integration repo -> corrected to Tineco-Integration. Fixes the broken HACS Documentation/Issues buttons.
- Upgrade GitHub Actions off the deprecated Node 20 runtime: actions/checkout v3/v4 -> v5, actions/setup-python v5 -> v6.
- Bump manifest to 2.4.2; CHANGELOG and README updated.

The earlier HACS "structure not compliant" error was a stale run against the now-deleted issue_28_29 branch (it fell back to the default branch); main is compliant.