### PR TITLE
Add release guardrails to prevent regressions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,13 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0  # need full history to verify the tag is on main
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
 
       - name: Get version from manifest
         id: version
@@ -22,20 +29,36 @@ jobs:
           version=$(cat custom_components/tineco/manifest.json | jq -r '.version')
           echo "version=$version" >> $GITHUB_OUTPUT
 
-      - name: Validate version matches tag
+      - name: Validate release consistency
+        # Guardrail (lessons learned): tag<->manifest version match, repo URLs,
+        # README version, and CHANGELOG section are all verified by one script
+        # that also runs on every PR. Pre-release suffixes (-rc/-beta/-alpha)
+        # are stripped before the tag/version comparison.
         if: github.event_name == 'release'
         run: |
-          # Strip the leading "v" and any pre-release suffix so that
-          # v2.2.14-rc1 / v2.2.14-beta1 / v2.2.14-alpha1 all validate against
-          # manifest.version = "2.2.14". Pre-release builds keep semantic
-          # versioning while still being gated by this check.
-          raw="${GITHUB_REF#refs/tags/v}"
-          tag_version="${raw%%-*}"
-          manifest_version="${{ steps.version.outputs.version }}"
-          if [ "$tag_version" != "$manifest_version" ]; then
-            echo "Error: Tag version ($tag_version, from $raw) does not match manifest version ($manifest_version)"
-            exit 1
-          fi
+          python scripts/check_release_consistency.py --tag "${GITHUB_REF#refs/tags/}"
+
+      - name: Verify the release tag is on main
+        # Guardrail (lessons learned): releases must be cut from the default
+        # branch, never from a feature branch. Stable releases must be an
+        # ancestor of main; pre-releases (-rc/-beta/-alpha) are exempt so they
+        # can still be tested off a branch.
+        if: github.event_name == 'release'
+        run: |
+          tag="${GITHUB_REF#refs/tags/}"
+          case "$tag" in
+            *-rc*|*-beta*|*-alpha*)
+              echo "Pre-release $tag — skipping on-main check."
+              ;;
+            *)
+              if git merge-base --is-ancestor "$tag" origin/main; then
+                echo "OK: $tag is on main."
+              else
+                echo "Error: stable release $tag is not an ancestor of origin/main. Cut releases from main."
+                exit 1
+              fi
+              ;;
+          esac
 
       - name: Create zip file
         run: |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -44,3 +44,21 @@ jobs:
       - name: Lint with ruff
         run: |
           ruff check custom_components/tineco
+
+  release-consistency:
+    # Guardrail (lessons learned): keep manifest version / repo URLs /
+    # README version / CHANGELOG in sync on every push & PR, so the next
+    # release can't ship a version mismatch or broken HACS links.
+    name: Release Consistency
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Check release consistency
+        run: python scripts/check_release_consistency.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ Two rules for contributors:
 
 ## [Unreleased]
 
+### Added
+- Release guardrails encoding lessons from past releases:
+  - `scripts/check_release_consistency.py` verifies manifest version is valid
+    semver, `documentation`/`issue_tracker` URLs point at this repo, the README
+    "Current version" matches, the CHANGELOG has the version's section, and
+    (with `--tag`) the tag matches the manifest version.
+  - `validate.yml` runs it on every push/PR (**Release Consistency** job).
+  - `release.yml` runs it with `--tag` on publish and additionally verifies a
+    stable release tag is an ancestor of `main` (pre-releases exempt).
+  - `tests/test_release_consistency.py` exercises the guard logic and fails if
+    the checked-in metadata drifts.
+
 ## [v2.4.2] - 2026-06-02
 
 ### Fixed

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -2,6 +2,27 @@
 
 Five steps. Skip none.
 
+## Automated guardrails (run before you tag)
+
+Most of the manual checks below are now enforced by CI so a release can't
+silently regress. You can run the same static checks locally any time:
+
+```
+python scripts/check_release_consistency.py            # version/URLs/README/CHANGELOG
+python scripts/check_release_consistency.py --tag vX.Y.Z   # also verify the tag
+```
+
+- **`validate.yml` → Release Consistency** runs the no-arg form on every push
+  and PR (manifest version is valid semver; `documentation`/`issue_tracker`
+  URLs point at *this* repo; README "Current version" matches; CHANGELOG has a
+  `## [vX.Y.Z]` section).
+- **`release.yml`** runs `--tag` on publish (tag↔manifest match, suffixes
+  stripped) **and** verifies a stable tag is an ancestor of `main`
+  (pre-releases are exempt so they can be tested off a branch).
+
+If CI is green these are already satisfied; the steps below are the human
+judgement parts.
+
 ## 1. Tests pass
 
 ```

--- a/scripts/check_release_consistency.py
+++ b/scripts/check_release_consistency.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Release-consistency guardrails for the Tineco HACS integration.
+
+Encodes the lessons learned from past releases so they can't silently
+regress. Run with no args for the static checks (safe anywhere):
+
+    python scripts/check_release_consistency.py
+
+On a tagged release, also pass the tag to cross-check it against the
+manifest version:
+
+    python scripts/check_release_consistency.py --tag v2.4.2
+
+Checks performed:
+
+1. manifest.json version is valid semver (X.Y.Z).
+2. manifest.json documentation / issue_tracker URLs point at THIS repo
+   (derived from the git remote, or $GITHUB_REPOSITORY in CI). Catches the
+   Tineco-HACS-Integration -> Tineco-Integration broken-link regression.
+3. README "Current version" line matches manifest.version.
+4. CHANGELOG has a `## [vX.Y.Z]` section for manifest.version (i.e. the
+   [Unreleased] entries were promoted on release).
+5. With --tag: the tag's version (minus any -rc/-beta/-alpha suffix) equals
+   manifest.version. Mirrors release.yml so a local check catches it first.
+
+Exit code 0 = all good; 1 = one or more failures (each printed).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MANIFEST = REPO_ROOT / "custom_components" / "tineco" / "manifest.json"
+README = REPO_ROOT / "README.md"
+CHANGELOG = REPO_ROOT / "CHANGELOG.md"
+
+SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+$")
+
+
+def _fail(errors: list[str], msg: str) -> None:
+    errors.append(msg)
+
+
+def _expected_repo_slug() -> str | None:
+    """Return 'owner/name' for this repo, from CI env or the git remote."""
+    env = os.environ.get("GITHUB_REPOSITORY")
+    if env:
+        return env.strip()
+    try:
+        url = subprocess.check_output(
+            ["git", "remote", "get-url", "origin"],
+            cwd=REPO_ROOT, text=True,
+        ).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+    # git@github.com:owner/name.git  or  https://github.com/owner/name.git
+    m = re.search(r"github\.com[:/]([^/]+/[^/]+?)(?:\.git)?$", url)
+    return m.group(1) if m else None
+
+
+def check_manifest_version(errors: list[str]) -> str:
+    data = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    version = str(data.get("version", "")).strip()
+    if not SEMVER_RE.match(version):
+        _fail(errors, f"manifest version {version!r} is not valid semver (X.Y.Z)")
+    return version
+
+
+def check_manifest_urls(errors: list[str]) -> None:
+    data = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    slug = _expected_repo_slug()
+    if not slug:
+        print("  (skipping URL repo-match check: could not determine repo slug)")
+        return
+    expected = f"https://github.com/{slug}"
+    for key in ("documentation", "issue_tracker"):
+        url = str(data.get(key, ""))
+        if not url.startswith(expected):
+            _fail(
+                errors,
+                f"manifest '{key}' = {url!r} does not point at this repo "
+                f"({expected}...). Update it so HACS links resolve.",
+            )
+
+
+def check_readme_version(errors: list[str], version: str) -> None:
+    text = README.read_text(encoding="utf-8")
+    m = re.search(r"Current version:\s*\*\*([0-9.]+)\*\*", text)
+    if not m:
+        _fail(errors, "README has no 'Current version: **X.Y.Z**' line")
+    elif m.group(1) != version:
+        _fail(
+            errors,
+            f"README 'Current version' = {m.group(1)} but manifest = {version}",
+        )
+
+
+def check_changelog(errors: list[str], version: str) -> None:
+    text = CHANGELOG.read_text(encoding="utf-8")
+    if f"## [v{version}]" not in text and f"## [{version}]" not in text:
+        _fail(
+            errors,
+            f"CHANGELOG has no '## [v{version}]' section. Promote the "
+            f"[Unreleased] entries to a v{version} heading on release.",
+        )
+
+
+def check_tag(errors: list[str], version: str, tag: str) -> None:
+    raw = tag[1:] if tag.startswith("v") else tag
+    tag_version = raw.split("-", 1)[0]  # strip -rc1 / -beta1 / -alpha1
+    if tag_version != version:
+        _fail(
+            errors,
+            f"tag {tag!r} -> version {tag_version} does not match manifest "
+            f"version {version}",
+        )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tag", help="release tag to cross-check (e.g. v2.4.2)")
+    args = parser.parse_args()
+
+    errors: list[str] = []
+
+    print("Checking release consistency...")
+    version = check_manifest_version(errors)
+    print(f"  manifest version: {version}")
+    check_manifest_urls(errors)
+    check_readme_version(errors, version)
+    check_changelog(errors, version)
+    if args.tag:
+        print(f"  cross-checking tag: {args.tag}")
+        check_tag(errors, version, args.tag)
+
+    if errors:
+        print("\nFAILED release-consistency checks:")
+        for e in errors:
+            print(f"  - {e}")
+        return 1
+
+    print("\nAll release-consistency checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_release_consistency.py
+++ b/tests/test_release_consistency.py
@@ -1,0 +1,72 @@
+"""Tests for the release-consistency guardrails.
+
+These run as part of the normal pytest suite so the guard logic itself
+can't silently rot, and so a version/URL/CHANGELOG drift fails tests too
+(not just the dedicated Release Consistency CI job).
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "check_release_consistency.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("check_release_consistency", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+crc = _load_module()
+
+
+def test_repo_is_currently_consistent():
+    """The checked-in manifest/README/CHANGELOG must be self-consistent."""
+    errors: list[str] = []
+    version = crc.check_manifest_version(errors)
+    crc.check_manifest_urls(errors)
+    crc.check_readme_version(errors, version)
+    crc.check_changelog(errors, version)
+    assert errors == [], "Release consistency drift: " + "; ".join(errors)
+
+
+def test_tag_check_strips_prerelease_suffixes():
+    """v2.4.2 / v2.4.2-rc1 / v2.4.2-beta3 all match manifest 2.4.2."""
+    for tag in ("v2.4.2", "v2.4.2-rc1", "v2.4.2-beta3", "2.4.2-alpha1"):
+        errors: list[str] = []
+        crc.check_tag(errors, "2.4.2", tag)
+        assert errors == [], f"{tag} should match 2.4.2 but got {errors}"
+
+
+def test_tag_check_rejects_mismatch():
+    errors: list[str] = []
+    crc.check_tag(errors, "2.4.2", "v9.9.9")
+    assert errors, "mismatched tag should be rejected"
+
+
+@pytest.mark.parametrize("url", [
+    "https://github.com/owner/wrong-repo",
+    "https://github.com/owner/Tineco-HACS-Integration",
+])
+def test_url_check_rejects_wrong_repo(url, monkeypatch, tmp_path):
+    """A manifest URL pointing at a different repo must be flagged."""
+    import json
+
+    fake_manifest = tmp_path / "manifest.json"
+    fake_manifest.write_text(json.dumps({
+        "version": "2.4.2",
+        "documentation": url,
+        "issue_tracker": url + "/issues",
+    }), encoding="utf-8")
+
+    monkeypatch.setattr(crc, "MANIFEST", fake_manifest)
+    monkeypatch.setattr(crc, "_expected_repo_slug", lambda: "owner/Tineco-Integration")
+
+    errors: list[str] = []
+    crc.check_manifest_urls(errors)
+    assert errors, f"URL {url} should be rejected"


### PR DESCRIPTION
Encodes the lessons from the 2.4.x release cycle as automated checks so future releases can't silently regress:

- scripts/check_release_consistency.py: manifest semver, repo-URL match (catches the Tineco-HACS-Integration broken-link bug), README version match, CHANGELOG section present, and tag<->manifest match (--tag).
- validate.yml: new "Release Consistency" job runs it on every push/PR.
- release.yml: runs it with --tag on publish AND verifies a stable tag is an ancestor of main (pre-releases exempt) so releases can't be cut from a feature branch.
- tests/test_release_consistency.py: unit-tests the guard logic and fails if checked-in metadata drifts.
- RELEASE_CHECKLIST.md documents the guardrails.